### PR TITLE
통합 테스트, E2E 테스트, 동시성 테스트 추가

### DIFF
--- a/src/test/java/io/hhplus/tdd/medium_e2e/PointControllerTest.java
+++ b/src/test/java/io/hhplus/tdd/medium_e2e/PointControllerTest.java
@@ -1,0 +1,255 @@
+package io.hhplus.tdd.medium_e2e;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.hhplus.tdd.controller.PointController;
+import io.hhplus.tdd.controller.request.UserPointUpdate;
+import io.hhplus.tdd.domain.TransactionType;
+import io.hhplus.tdd.infrastructure.PointHistoryTable;
+import io.hhplus.tdd.infrastructure.UserPointTable;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * PointController 클래스에 대한 E2E 테스트입니다.
+ * 각 테스트 테스트 메서드에 대한 주석 내용은 테스트 메서드 이름으로 대신하였습니다.
+ * 테스트 메서드간 ApplicationContext 의 싱글톤 빈에 접근해 상태를 변경하므로 @DirtiesContext 로
+ * 각 테스트 메서드마다 context cache 를 삭제하도록 해 독립적인 환경을 만들었습니다.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+public class PointControllerTest {
+
+    private final PointHistoryTable pointHistoryTable;
+    private final UserPointTable userPointTable;
+    private final PointController pointController;
+    private final MockMvc mockMvc;
+    private final ObjectMapper objectMapper;
+
+    @Autowired
+    public PointControllerTest(PointHistoryTable pointHistoryTable, UserPointTable userPointTable,
+        PointController pointController, MockMvc mockMvc, ObjectMapper objectMapper) {
+
+        this.pointHistoryTable = pointHistoryTable;
+        this.userPointTable = userPointTable;
+        this.pointController = pointController;
+        this.mockMvc = mockMvc;
+        this.objectMapper = objectMapper;
+    }
+
+    @Test
+    @DirtiesContext
+    public void 특정_유저의_포인트_정보를_조회할_수_있다() throws Exception {
+        // given
+        userPointTable.insertOrUpdate(7L, 500);
+
+        // when
+        // then
+        mockMvc.perform(get("/point/7"))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(7L))
+            .andExpect(jsonPath("$.point").value(500L));
+    }
+
+    @Test
+    @DirtiesContext
+    public void 포인트_충전한_적이_없는_유저의_포인트_정보를_조회할_시_포인트가_0_인_포인트_정보를_반환한다() throws Exception {
+        // given
+        // when
+        // then
+        mockMvc.perform(get("/point/7"))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(7L))
+            .andExpect(jsonPath("$.point").value(0L));
+    }
+
+    @Test
+    @DirtiesContext
+    public void 특정_유저의_포인트_히스토리를_조회할_수_있다() throws Exception {
+        // given
+        pointHistoryTable.insert(7L, 500L, TransactionType.CHARGE, 12_345L);
+        pointHistoryTable.insert(7L, 300L, TransactionType.USE, 67_890L);
+
+        // when
+        // then
+        mockMvc.perform(get("/point/7/histories"))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0]").exists())
+            .andExpect(jsonPath("$[0].id").value(1L))
+            .andExpect(jsonPath("$[0].userId").value(7L))
+            .andExpect(jsonPath("$[0].amount").value(500L))
+            .andExpect(jsonPath("$[0].type").value("CHARGE"))
+            .andExpect(jsonPath("$[0].updateMillis").value(12_345L))
+            .andExpect(jsonPath("$[1].id").value(2L))
+            .andExpect(jsonPath("$[1].userId").value(7L))
+            .andExpect(jsonPath("$[1].amount").value(300L))
+            .andExpect(jsonPath("$[1].type").value("USE"))
+            .andExpect(jsonPath("$[1].updateMillis").value(67_890L));
+    }
+
+    @Test
+    @DirtiesContext
+    public void 특정_유저의_포인트_충전_내역이_없을_시_빈_내역을_반환한다() throws Exception {
+        // given
+        // when
+        // then
+        mockMvc.perform(get("/point/7/histories"))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$").isEmpty());
+    }
+
+    @Test
+    @DirtiesContext
+    public void 특정_유저의_포인트를_충전할_시_합산후_포인트_정산_정보를_반환한다() throws Exception {
+        // given
+        userPointTable.insertOrUpdate(7L, 1_000L);
+
+        // when
+        // then
+        mockMvc.perform(patch("/point/7/charge")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(UserPointUpdate.builder()
+                    .amount(2_000L)
+                    .build())))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(7L))
+            .andExpect(jsonPath("$.point").value(1_000L + 2_000L));
+    }
+
+    @Test
+    @DirtiesContext
+    public void 특정_유저의_포인트를_충전할_시_충전내역이_히스토리에_기록된다() throws Exception {
+        // given
+        // when
+        pointController.charge(7L, UserPointUpdate.builder()
+            .amount(1_000L)
+            .build());
+
+        //then
+        mockMvc.perform(get("/point/7/histories"))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0]").exists())
+            .andExpect(jsonPath("$[0].id").value(1L))
+            .andExpect(jsonPath("$[0].userId").value(7L))
+            .andExpect(jsonPath("$[0].amount").value(1_000L))
+            .andExpect(jsonPath("$[0].type").value("CHARGE"));
+    }
+
+    @Test
+    @DirtiesContext
+    public void 특정_유저의_포인트를_사용할_시_포인트_차감후_포인트_정산_정보를_반환한다() throws Exception {
+        // given
+        userPointTable.insertOrUpdate(7L, 5_000L);
+        UserPointUpdate userPointUpdate = UserPointUpdate.builder()
+            .amount(2_000L)
+            .build();
+
+        // when
+        // then
+        mockMvc.perform(patch("/point/7/use")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(userPointUpdate)))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(7L))
+            .andExpect(jsonPath("$.point").value(5_000L - 2_000L));
+    }
+
+    @Test
+    @DirtiesContext
+    public void 특정_유저의_포인트를_사용할_시_사용내역이_히스토리에_기록된다() throws Exception {
+        // given
+        pointController.charge(7L, UserPointUpdate.builder()
+            .amount(5_000L)
+            .build());
+
+        // when
+        pointController.use(7L, UserPointUpdate.builder()
+            .amount(2_000L)
+            .build());
+
+        //then
+        mockMvc.perform(get("/point/7/histories"))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0]").exists())
+            .andExpect(jsonPath("$[0].id").value(1L))
+            .andExpect(jsonPath("$[0].userId").value(7L))
+            .andExpect(jsonPath("$[0].amount").value(5_000L))
+            .andExpect(jsonPath("$[0].type").value("CHARGE"))
+            .andExpect(jsonPath("$[1].id").value(2L))
+            .andExpect(jsonPath("$[1].userId").value(7L))
+            .andExpect(jsonPath("$[1].amount").value(2_000L))
+            .andExpect(jsonPath("$[1].type").value("USE"));
+    }
+
+    @Test
+    @DirtiesContext
+    public void 포인트_충전시_0_이하의_정수를_충전포인트_값으로_입력할_경우_에러를_던진다() throws Exception {
+        // given
+        // when
+        // then
+        mockMvc.perform(patch("/point/7/charge")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(UserPointUpdate.builder()
+                    .amount(-500L)
+                    .build())))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("400"))
+            .andExpect(jsonPath("$.message").value("잘못된 포인트 입력입니다. 입력은 양의 정수로만 가능합니다."));
+    }
+
+    @Test
+    @DirtiesContext
+    public void 포인트_사용시_0_이하의_정수를_사용포인트_값으로_입력할_경우_에러를_던진다() throws Exception {
+        // given
+        // when
+        // then
+        mockMvc.perform(patch("/point/7/use")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(UserPointUpdate.builder()
+                    .amount(-500L)
+                    .build())))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("400"))
+            .andExpect(jsonPath("$.message").value("잘못된 포인트 입력입니다. 입력은 양의 정수로만 가능합니다."));
+    }
+
+    @Test
+    @DirtiesContext
+    public void 특정_유저가_보유한_포인트보다_많은_포인트를_사용하려_할_경우_에러를_반환한다() throws Exception {
+        // given
+        userPointTable.insertOrUpdate(7L, 1_000L);
+
+        // when
+        // then
+        mockMvc.perform(patch("/point/7/use")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(UserPointUpdate.builder()
+                    .amount(1_500L)
+                    .build())))
+            .andDo(print())
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value("409"))
+            .andExpect(jsonPath("$.message").value("포인트 잔액이 부족합니다."));
+    }
+}
+

--- a/src/test/java/io/hhplus/tdd/medium_integrated/PointControllerTest.java
+++ b/src/test/java/io/hhplus/tdd/medium_integrated/PointControllerTest.java
@@ -1,0 +1,254 @@
+package io.hhplus.tdd.medium_integrated;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import io.hhplus.tdd.controller.PointController;
+import io.hhplus.tdd.controller.request.UserPointUpdate;
+import io.hhplus.tdd.domain.PointHistory;
+import io.hhplus.tdd.domain.TransactionType;
+import io.hhplus.tdd.domain.UserPoint;
+import io.hhplus.tdd.domain.exception.BadInputPointValueException;
+import io.hhplus.tdd.domain.exception.InsufficientPointsException;
+import io.hhplus.tdd.infrastructure.PointHistoryTable;
+import io.hhplus.tdd.infrastructure.UserPointTable;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
+
+/**
+ * PointController 클래스에 대한 통합 테스트입니다.
+ * 각 테스트 테스트 메서드에 대한 주석 내용은 테스트 메서드 이름으로 대신하였습니다.
+ * 테스트 메서드간 ApplicationContext 의 싱글톤 빈에 접근해 상태를 변경하므로 @DirtiesContext 로
+ * 각 테스트 메서드마다 context cache 를 삭제하도록 해 독립적인 환경을 만들었습니다.
+ */
+@SpringBootTest
+public class PointControllerTest {
+
+    private final PointHistoryTable pointHistoryTable;
+    private final UserPointTable userPointTable;
+    private final PointController pointController;
+
+    @Autowired
+    public PointControllerTest(PointHistoryTable pointHistoryTable,
+        UserPointTable userPointTable, PointController pointController) {
+
+        this.pointHistoryTable = pointHistoryTable;
+        this.userPointTable = userPointTable;
+        this.pointController = pointController;
+    }
+
+    @Test
+    @DirtiesContext
+    public void 특정_유저의_포인트_정보를_조회할_수_있다() {
+        // given
+        userPointTable.insertOrUpdate(7L, 500);
+
+        // when
+        ResponseEntity<UserPoint> result = pointController.point(7L);
+
+        // then
+        assertAll(
+            () -> assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(200)),
+            () -> assertThat(result.getBody()).isNotNull(),
+            () -> assertThat(result.getBody().id()).isEqualTo(7L),
+            () -> assertThat(result.getBody().point()).isEqualTo(500L)
+        );
+    }
+
+    @Test
+    @DirtiesContext
+    public void 포인트_충전한_적이_없는_유저의_포인트_정보를_조회할_시_포인트가_0_인_포인트_정보를_반환한다() {
+        // given
+        // when
+        ResponseEntity<UserPoint> result = pointController.point(7L);
+
+        // then
+        assertAll(
+            () -> assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(200)),
+            () -> assertThat(result.getBody().id()).isEqualTo(7L),
+            () -> assertThat(result.getBody().point()).isEqualTo(0L)
+        );
+    }
+
+    @Test
+    @DirtiesContext
+    public void 특정_유저의_포인트_히스토리를_조회할_수_있다() {
+        // given
+        pointHistoryTable.insert(7L, 500L, TransactionType.CHARGE, 12_345L);
+        pointHistoryTable.insert(7L, 300L, TransactionType.USE, 67_890L);
+
+        // when
+        ResponseEntity<List<PointHistory>> result = pointController.history(7L);
+
+        // then
+        assertAll(
+            () -> assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(200)),
+            () -> assertThat(result.getBody()).isNotNull(),
+            () -> assertThat(result.getBody().size()).isEqualTo(2),
+            () -> assertThat(result.getBody().get(0).id()).isEqualTo(1L),
+            () -> assertThat(result.getBody().get(0).userId()).isEqualTo(7L),
+            () -> assertThat(result.getBody().get(0).amount()).isEqualTo(500L),
+            () -> assertThat(result.getBody().get(0).type()).isEqualTo(TransactionType.CHARGE),
+            () -> assertThat(result.getBody().get(0).updateMillis()).isEqualTo(12_345L),
+            () -> assertThat(result.getBody().get(1).id()).isEqualTo(2L),
+            () -> assertThat(result.getBody().get(1).userId()).isEqualTo(7L),
+            () -> assertThat(result.getBody().get(1).amount()).isEqualTo(300L),
+            () -> assertThat(result.getBody().get(1).type()).isEqualTo(TransactionType.USE),
+            () -> assertThat(result.getBody().get(1).updateMillis()).isEqualTo(67_890L)
+        );
+    }
+
+    @Test
+    @DirtiesContext
+    public void 특정_유저의_포인트_충전_내역이_없을_시_빈_내역을_반환한다() {
+        // given
+        // when
+        ResponseEntity<List<PointHistory>> result = pointController.history(7L);
+
+        // then
+        assertAll(
+            () -> assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(200)),
+            () -> assertThat(result.getBody()).isEmpty()
+        );
+    }
+
+    @Test
+    @DirtiesContext
+    public void 특정_유저의_포인트를_충전할_시_합산후_포인트_정산_정보를_반환한다() {
+        // given
+        UserPointUpdate userPointUpdate = UserPointUpdate.builder()
+            .amount(500L)
+            .build();
+
+        // when
+        pointController.charge(7L, userPointUpdate);
+        ResponseEntity<UserPoint> result = pointController.charge(7L, userPointUpdate);
+
+        // then
+        assertAll(
+            () -> assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(200)),
+            () -> assertThat(result.getBody()).isNotNull(),
+            () -> assertThat(result.getBody().id()).isEqualTo(7L),
+            () -> assertThat(result.getBody().point()).isEqualTo(500L + 500L)
+        );
+    }
+
+    @Test
+    @DirtiesContext
+    public void 특정_유저의_포인트를_충전할_시_충전내역이_히스토리에_기록된다() {
+        // given
+        // when
+        pointController.charge(7L, UserPointUpdate.builder()
+            .amount(500L)
+            .build());
+        ResponseEntity<List<PointHistory>> result = pointController.history(7L);
+
+        // then
+        assertAll(
+            () -> assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(200)),
+            () -> assertThat(result.getBody()).isNotNull(),
+            () -> assertThat(result.getBody().size()).isEqualTo(1),
+            () -> assertThat(result.getBody().get(0).id()).isEqualTo(1L),
+            () -> assertThat(result.getBody().get(0).userId()).isEqualTo(7L),
+            () -> assertThat(result.getBody().get(0).amount()).isEqualTo(500L),
+            () -> assertThat(result.getBody().get(0).type()).isEqualTo(TransactionType.CHARGE)
+        );
+    }
+
+    @Test
+    @DirtiesContext
+    public void 특정_유저의_포인트를_사용할_시_포인트_차감후_포인트_정산_정보를_반환한다() {
+        // given
+        userPointTable.insertOrUpdate(7L, 1_000L);
+
+        // when
+        ResponseEntity<UserPoint> result = pointController.use(7L, UserPointUpdate.builder()
+            .amount(100L)
+            .build());
+
+        // then
+        assertAll(
+            () -> assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(200)),
+            () -> assertThat(result.getBody()).isNotNull(),
+            () -> assertThat(result.getBody().id()).isEqualTo(7L),
+            () -> assertThat(result.getBody().point()).isEqualTo(1_000L - 100L)
+        );
+    }
+
+    @Test
+    @DirtiesContext
+    public void 특정_유저의_포인트를_사용할_시_사용내역이_히스토리에_기록된다() {
+        // given
+        userPointTable.insertOrUpdate(7L, 1_000L);
+        pointHistoryTable.insert(7L, 1_000L, TransactionType.CHARGE, 12_345L);
+
+        // when
+        pointController.use(7L, UserPointUpdate.builder()
+            .amount(300L)
+            .build());
+        ResponseEntity<List<PointHistory>> result = pointController.history(7L);
+
+        // then
+        assertAll(
+            () -> assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(200)),
+            () -> assertThat(result.getBody()).isNotNull(),
+            () -> assertThat(result.getBody().size()).isEqualTo(2),
+            () -> assertThat(result.getBody().get(0).id()).isEqualTo(1L),
+            () -> assertThat(result.getBody().get(0).userId()).isEqualTo(7L),
+            () -> assertThat(result.getBody().get(0).amount()).isEqualTo(1_000L),
+            () -> assertThat(result.getBody().get(0).type()).isEqualTo(TransactionType.CHARGE),
+            () -> assertThat(result.getBody().get(1).id()).isEqualTo(2L),
+            () -> assertThat(result.getBody().get(1).userId()).isEqualTo(7L),
+            () -> assertThat(result.getBody().get(1).amount()).isEqualTo(300L),
+            () -> assertThat(result.getBody().get(1).type()).isEqualTo(TransactionType.USE)
+        );
+    }
+
+    @Test
+    @DirtiesContext
+    public void 포인트_충전시_0_이하의_정수를_충전포인트_값으로_입력할_경우_에러를_던진다() {
+        // given
+        // when
+        // then
+        assertThatThrownBy(() -> {
+            pointController.charge(7L, UserPointUpdate.builder()
+                .amount(-500L)
+                .build());
+        }).isInstanceOf(BadInputPointValueException.class);
+    }
+
+    @Test
+    @DirtiesContext
+    public void 포인트_사용시_0_이하의_정수를_사용포인트_값으로_입력할_경우_에러를_던진다() {
+        // given
+        // when
+        // then
+        assertThatThrownBy(() -> {
+            pointController.use(7L, UserPointUpdate.builder()
+                .amount(-500L)
+                .build());
+        }).isInstanceOf(BadInputPointValueException.class);
+    }
+
+    @Test
+    @DirtiesContext
+    public void 특정_유저가_보유한_포인트보다_많은_포인트를_사용하려_할_경우_에러를_반환한다() {
+        // given
+        userPointTable.insertOrUpdate(7L, 200L);
+
+        // when
+        // then
+        assertThatThrownBy(() -> {
+            pointController.use(7L, UserPointUpdate.builder()
+                .amount(1_000L)
+                .build());
+        }).isInstanceOf(InsufficientPointsException.class);
+    }
+}
+

--- a/src/test/java/io/hhplus/tdd/medium_integrated/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/medium_integrated/PointServiceTest.java
@@ -1,0 +1,217 @@
+package io.hhplus.tdd.medium_integrated;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import io.hhplus.tdd.domain.PointHistory;
+import io.hhplus.tdd.domain.TransactionType;
+import io.hhplus.tdd.domain.UserPoint;
+import io.hhplus.tdd.domain.exception.BadInputPointValueException;
+import io.hhplus.tdd.domain.exception.InsufficientPointsException;
+import io.hhplus.tdd.infrastructure.PointHistoryTable;
+import io.hhplus.tdd.infrastructure.UserPointTable;
+import io.hhplus.tdd.service.PointService;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+
+/**
+ * PointService 클래스에 대한 통합 테스트입니다.
+ * 각 테스트 테스트 메서드에 대한 주석 내용은 테스트 메서드 이름으로 대신하였습니다.
+ * 테스트 메서드간 ApplicationContext 의 싱글톤 빈에 접근해 상태를 변경하므로 @DirtiesContext 로
+ * 각 테스트 메서드마다 context cache 를 삭제하도록 해 독립적인 환경을 만들었습니다.
+ */
+@SpringBootTest
+public class PointServiceTest {
+
+    private final PointHistoryTable pointHistoryTable;
+    private final UserPointTable userPointTable;
+    private final PointService pointService;
+
+    @Autowired
+    public PointServiceTest(PointHistoryTable pointHistoryTable,
+        UserPointTable userPointTable, PointService pointService) {
+
+        this.pointHistoryTable = pointHistoryTable;
+        this.userPointTable = userPointTable;
+        this.pointService = pointService;
+    }
+
+    @Test
+    @DirtiesContext
+    public void 특정_유저의_포인트_정보를_조회할_수_있다() {
+        // given
+        userPointTable.insertOrUpdate(7L, 500);
+
+        // when
+        UserPoint result = pointService.getByUserId(7L);
+
+        // then
+        assertAll(
+            () -> assertThat(result.id()).isEqualTo(7L),
+            () -> assertThat(result.point()).isEqualTo(500L)
+        );
+    }
+
+    @Test
+    @DirtiesContext
+    public void 포인트_충전한_적이_없는_유저의_포인트_정보를_조회할_시_포인트가_0_인_포인트_정보를_반환한다() {
+        // given
+        // when
+        UserPoint result = pointService.getByUserId(7L);
+
+        // then
+        assertAll(
+            () -> assertThat(result.id()).isEqualTo(7L),
+            () -> assertThat(result.point()).isEqualTo(0L)
+        );
+    }
+
+    @Test
+    @DirtiesContext
+    public void 특정_유저의_포인트_히스토리를_조회할_수_있다() {
+        // given
+        pointHistoryTable.insert(7L, 500L, TransactionType.CHARGE, 12_345L);
+        pointHistoryTable.insert(7L, 300L, TransactionType.USE, 67_890L);
+
+        // when
+        List<PointHistory> result = pointService.getHistoriesByUserId(7L);
+
+        // then
+        assertAll(
+            () -> assertThat(result.size()).isEqualTo(2),
+            () -> assertThat(result.get(0).id()).isEqualTo(1L),
+            () -> assertThat(result.get(0).userId()).isEqualTo(7L),
+            () -> assertThat(result.get(0).amount()).isEqualTo(500L),
+            () -> assertThat(result.get(0).type()).isEqualTo(TransactionType.CHARGE),
+            () -> assertThat(result.get(0).updateMillis()).isEqualTo(12_345L),
+            () -> assertThat(result.get(1).id()).isEqualTo(2L),
+            () -> assertThat(result.get(1).userId()).isEqualTo(7L),
+            () -> assertThat(result.get(1).amount()).isEqualTo(300L),
+            () -> assertThat(result.get(1).type()).isEqualTo(TransactionType.USE),
+            () -> assertThat(result.get(1).updateMillis()).isEqualTo(67_890L)
+        );
+    }
+
+    @Test
+    @DirtiesContext
+    public void 특정_유저의_포인트_충전_내역이_없을_시_빈_내역을_반환한다() {
+        // given
+        // when
+        List<PointHistory> result = pointService.getHistoriesByUserId(7L);
+
+        // then
+        assertAll(
+            () -> assertThat(result).isEmpty()
+        );
+    }
+
+    @Test
+    @DirtiesContext
+    public void 특정_유저의_포인트를_충전할_시_합산후_포인트_정산_정보를_반환한다() {
+        // given
+        // when
+        pointService.charge(7L, 500L);
+        UserPoint result = pointService.charge(7L, 500L);
+
+        // then
+        assertAll(
+            () -> assertThat(result.id()).isEqualTo(7L),
+            () -> assertThat(result.point()).isEqualTo(1_000L)
+        );
+    }
+
+    @Test
+    @DirtiesContext
+    public void 특정_유저의_포인트를_충전할_시_충전내역이_히스토리에_기록된다() {
+        // given
+        // when
+        pointService.charge(7L, 500L);
+        List<PointHistory> result = pointService.getHistoriesByUserId(7L);
+
+        // then
+        assertAll(
+            () -> assertThat(result.size()).isEqualTo(1),
+            () -> assertThat(result.get(0).id()).isEqualTo(1L),
+            () -> assertThat(result.get(0).userId()).isEqualTo(7L),
+            () -> assertThat(result.get(0).amount()).isEqualTo(500L),
+            () -> assertThat(result.get(0).type()).isEqualTo(TransactionType.CHARGE)
+        );
+    }
+
+    @Test
+    @DirtiesContext
+    public void 특정_유저의_포인트를_사용할_시_포인트_차감후_포인트_정산_정보를_반환한다() {
+        // given
+        userPointTable.insertOrUpdate(7L, 1_000L);
+
+        // when
+        UserPoint result = pointService.use(7L, 100L);
+
+        // then
+        assertAll(
+            () -> assertThat(result.id()).isEqualTo(7L),
+            () -> assertThat(result.point()).isEqualTo(1_000L - 100L)
+        );
+    }
+
+    @Test
+    @DirtiesContext
+    public void 특정_유저의_포인트를_사용할_시_사용내역이_히스토리에_기록된다() {
+        // given
+        userPointTable.insertOrUpdate(7L, 1_000L);
+        pointHistoryTable.insert(7L, 1_000L, TransactionType.CHARGE, 12_345L);
+
+        // when
+        pointService.use(7L, 300L);
+        List<PointHistory> result = pointService.getHistoriesByUserId(7L);
+
+        // then
+        assertAll(
+            () -> assertThat(result.size()).isEqualTo(2),
+            () -> assertThat(result.get(1).id()).isEqualTo(2L),
+            () -> assertThat(result.get(1).userId()).isEqualTo(7L),
+            () -> assertThat(result.get(1).amount()).isEqualTo(300L),
+            () -> assertThat(result.get(1).type()).isEqualTo(TransactionType.USE)
+        );
+    }
+
+    @Test
+    @DirtiesContext
+    public void 포인트_충전시_0_이하의_정수를_충전포인트_값으로_입력할_경우_에러를_던진다() {
+        // given
+        // when
+        // then
+        assertThatThrownBy(() -> {
+            pointService.charge(7L, -500L);
+        }).isInstanceOf(BadInputPointValueException.class);
+    }
+
+    @Test
+    @DirtiesContext
+    public void 포인트_사용시_0_이하의_정수를_사용포인트_값으로_입력할_경우_에러를_던진다() {
+        // given
+        // when
+        // then
+        assertThatThrownBy(() -> {
+            pointService.use(7L, -500L);
+        }).isInstanceOf(BadInputPointValueException.class);
+    }
+
+    @Test
+    @DirtiesContext
+    public void 특정_유저가_보유한_포인트보다_많은_포인트를_사용하려_할_경우_에러를_반환한다() {
+        // given
+        userPointTable.insertOrUpdate(7L, 200L);
+
+        // when
+        // then
+        assertThatThrownBy(() -> {
+            pointService.use(7L, 500L);
+        }).isInstanceOf(InsufficientPointsException.class);
+    }
+}


### PR DESCRIPTION
# 테스트 요약
- 분류: 단위 테스트
- 테스트 대상:
    - [x] controller 통합테스트(`@SpringBootTest`)
    - [x] service 통합테스트(`@SpringBootTest`)
    - [x] 2E2 테스트(`@SpringBootTest` + `MockMvc`)
- 내용:
    - 각 메서드 성공 케이스 검증
    - 각 메서드 실패 케이스 검증
    - 포인트 충전/사용시 0 또는 음수 등 유효하지 않은 입력값 처리에 대한 검증
    - 동시성 테스트

# 어려웠던 점
- 메서드만 보고 테스트 흐름을 바로 파악할 수 있도록 테스트 클래스 최상단에서 `@BeforeEach` 등 초기세팅 없이 각 메서드마다 (중복 내용을) 하드코딩 했습니다. 다만 기능 구현중 스펙이 약간 변경되어도 하나하나 일일이 모두 수정을 해야했어서...실무에선 어느 정도 선이 베스트 프랙티스일까 궁금해졌습니다.
- DB를 다룰 때 동시성은 JDBC의 `@Transactional`에만 전적으로 의지했는데, 직접 언어에서 다뤄보려니 생소하고 어려웠던 것 같습니다.